### PR TITLE
use torch.gather instead of direct indexing

### DIFF
--- a/elastic_weight_consolidation.py
+++ b/elastic_weight_consolidation.py
@@ -27,7 +27,7 @@ class ElasticWeightConsolidation:
             if i > num_batch:
                 break
             output = F.log_softmax(self.model(input), dim=1)
-            log_liklihoods.append(output[:, target])
+            log_liklihoods.append(torch.gather(output, dim=1, index=target.unsqueeze(-1)))
         log_likelihood = torch.cat(log_liklihoods).mean()
         grad_log_liklihood = autograd.grad(log_likelihood, self.model.parameters())
         _buff_param_names = [param[0].replace('.', '__') for param in self.model.named_parameters()]


### PR DESCRIPTION
Instead of this line:

`log_liklihoods.append(output[:, target])`

have this line:

`log_liklihoods.append(torch.gather(output, dim=1, index=target.unsqueeze(-1)))`

Why?

Assume our output is 100x4 which means batch size is 100 and we have 4 classes. Target is a (100,) vector of classes, by indexing output[:, target] we will create a 100x100 matrix, instead of gathering the loglikelihoods 100x1 that we desire.

The torch.gather function does this propoerly.